### PR TITLE
Use the appropriate RPM version.

### DIFF
--- a/attributes/repositories.rb
+++ b/attributes/repositories.rb
@@ -21,5 +21,5 @@
 default['boundary_meter']['repositories']['apt']['url'] = 'http://apt.boundary.com/ubuntu/'
 default['boundary_meter']['repositories']['apt']['key'] = 'http://apt.boundary.com/APT-GPG-KEY-Boundary'
 
-default['boundary_meter']['repositories']['yum']['url'] = 'https://yum.boundary.com/centos/os/6.5'
+default['boundary_meter']['repositories']['yum']['url'] = 'https://yum.boundary.com/centos/os'
 default['boundary_meter']['repositories']['yum']['key'] = 'https://yum.boundary.com/RPM-GPG-KEY-Boundary'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@boundary.com'
 license          'Apache 2.0'
 description      'Installs/Configures boundary-meter'
 long_description 'Installs/Configures boundary-meter'
-version          '2.0.5'
+version          '2.0.6'
 
 %w{ ubuntu debian rhel centos amazon scientific }.each do |os|
   supports os

--- a/recipes/dependencies.rb
+++ b/recipes/dependencies.rb
@@ -30,9 +30,16 @@ when 'rhel'
     machine = 'x86_64'
   end
 
+  case node['platform']
+  when 'amazon'
+    version = '6'
+  else
+    version = node[:platform_version]
+  end
+
   yum_repository 'boundary' do
     description 'boundary'
-    baseurl "#{node['boundary_meter']['repositories']['yum']['url']}/#{machine}/"
+    baseurl "#{node['boundary_meter']['repositories']['yum']['url']}/#{version}/#{machine}/"
     gpgkey node['boundary_meter']['repositories']['yum']['key']
     action :create
   end


### PR DESCRIPTION
Move logic from the bprobe cookbook into the boundary-meter cookbook for
detecting RHEL-based versions. Use this to build the appropriate YUM
url.
