### PR TITLE
Use debian APT repository when in Debian OS

### DIFF
--- a/attributes/repositories.rb
+++ b/attributes/repositories.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-default['boundary_meter']['repositories']['apt']['url'] = 'http://apt.boundary.com/ubuntu/'
+default['boundary_meter']['repositories']['apt']['url'] = 'http://apt.boundary.com/%{distribution}/'
 default['boundary_meter']['repositories']['apt']['key'] = 'http://apt.boundary.com/APT-GPG-KEY-Boundary'
 
 default['boundary_meter']['repositories']['yum']['url'] = 'http://yum.boundary.com/centos/os'

--- a/recipes/dependencies.rb
+++ b/recipes/dependencies.rb
@@ -20,7 +20,7 @@
 # limitations under the License.
 #
 
-case node['platform_family']
+case family = node['platform_family']
 when 'rhel'
   case node['kernel']['machine']
   # There are no i686 meter builds
@@ -49,10 +49,15 @@ when 'debian', 'ubuntu'
     action :upgrade
   end
 
+  components = {
+    'debian' => 'main',
+    'ubuntu' => 'universe'
+  }
+
   apt_repository 'boundary' do
-    uri boundary_data('repositories')['apt']['url']
+    uri boundary_data('repositories')['apt']['url'] % { distribution: family }
     distribution node['lsb']['codename']
-    components ['universe']
+    components Array(components[family])
     key boundary_data('repositories')['apt']['key']
   end
 end


### PR DESCRIPTION
Cookbook says that `debian` is supported as an OS, but when trying to add APT repository no candidate version is available:

`ERROR: apt_package[boundary-meter] (boundary-meter::default line 25) had an error: Chef::Exceptions::package: No candidate version available for boundary-meter`

This is due APT repo `url` and `components` are different from ubuntu.

This PR makes it compatible with Debian OS

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/boundary/boundary-meter_cookbook/8)

<!-- Reviewable:end -->
