### PR TITLE
Chef if data_bag exist before getting item

### DIFF
--- a/libraries/boundary_data.rb
+++ b/libraries/boundary_data.rb
@@ -31,9 +31,9 @@ class Chef
 
     def boundary_data_merge(namespace='boundary_meter')
       databag, item = namespace.split('_')
-      
-      return node[namespace] unless data_bag(databag).include?(item)
-      
+
+      return node[namespace] unless item_in_data_bag?(databag, item)
+
       node[namespace].merge(data_bag_item(databag, item).to_hash)
     end
 
@@ -41,18 +41,18 @@ class Chef
 
     def from_data_bag(value, namespace)
       databag, item = namespace.split('_')
-      
-      if Chef::DataBag.list.include?(databag)
-        if data_bag(databag).include?(item)
-          return data_bag_item(databag, item)[value]
-        end
-      end
+
+      return data_bag_item(databag, item)[value] if item_in_data_bag?(databag, item)
 
       nil
     end
 
     def from_node_attr(value, namespace)
       return node[namespace][value]
+    end
+
+    def item_in_data_bag?(databag, item)
+      Chef::DataBag.list.include?(databag) && data_bag(databag).include?(item)
     end
   end
 end


### PR DESCRIPTION
If no data_bag named `boundary` is created `default` recipe does not converge.

This PR checks `boundary` data_bag exists before checking for an item.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/boundary/boundary-meter_cookbook/9)
<!-- Reviewable:end -->
